### PR TITLE
$IMGH,$IMGW set by xrandr resolution calls for both width and height

### DIFF
--- a/.gifbg
+++ b/.gifbg
@@ -7,10 +7,8 @@ exit 1
 fi
 
 #get screen resolution
-#SCRH=`xrandr | awk '/current/ { print $8 }'`
-SCRH=1920
-SCRW=1080
-SCRW=${SCRW%\,}
+SCRH=`xrandr | awk '/current/ { print $8 }'`
+SCRW=`xrandr | awk '/current/ { print $10 }' | sed 'g/,//'`
 
 #get gif resolution
 IMGHW=`gifsicle --info $1 | awk '/logical/ { print $3 }'`


### PR DESCRIPTION
For those that may be interested in using this on their computer, this certainly alleviates setting the `.gifbg` script manually. 

Of course this hasn't resolved issues with resolution outside of `.gifbg`, where there are plenty of manually set locations, but this is just a small step I thought I'd submit a PR for

You already had `SCRW=${SCRW%\,}` even though you had commented out the xrandr solution as if you were looking to implement this so I did :smile: 
